### PR TITLE
Auto add skip-changelog to pre-commit config changes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -43,6 +43,8 @@ exclude-contributors:
   - 'pre-commit-ci'
 autolabeler:
   - label: 'skip-changelog'
+    files:
+      - '.pre-commit-config.yaml'
     branch:
       - '/chore\/.+/'
     title:


### PR DESCRIPTION
As most changes involving pre-commit configuration are unlikely to
need changelog entries, we add the label on these.
