### PR TITLE
Use dashes instead of asterisks for changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
 # Format and labels used by Ansible DevTools projects
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-# Use '-' instead of '*' for unordered list to match prettier settings
+# Use '-' instead of '*' for unordered list to match prettier behavior
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 categories:
   - title: 'Major Changes'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,8 @@
 # Format and labels used by Ansible DevTools projects
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+# Use '-' instead of '*' for unordered list to match prettier settings
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 categories:
   - title: 'Major Changes'
     labels:


### PR DESCRIPTION
Switch to dashes for changelog entries instead of asterisks in order to match prettier configuration and avoid reformatting.

We will still have to convert existing files to match prettier settings on each repo but this change ensures that out changelog entries are ready to be pasted into final `CHANGELOG.md` file.

This does not affect github rendering, not the vscode marketplace one as it seems that both are treated the same way.

Related: https://github.com/prettier/prettier/issues/4251
Related: https://github.com/ansible/vscode-ansible/pull/386