### PR TITLE
chore: avoid multiple label matches

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -46,32 +46,30 @@ autolabeler:
     files:
       - '.pre-commit-config.yaml'
     branch:
-      - '/(chore|ci|gha|test|zuul)\/.+/'
+      - '/^(chore|ci|gha|test|zuul)\/.+/'
     title:
-      - '/(chore|ci|gha|test|zuul):/i'
+      - '/^(chore|ci|gha|test|zuul):/i'
       - '/pre-commit autoupdate/'
     body:
       - '/type: chore/i'
   - label: 'bug'
-    branch:
-      - '/fix\/.+/'
     title:
-      - '/fix/i'
+      - '/^fix/i'
     body:
       - '/type: fix/i'
   - label: 'enhancement'
     title:
-      - '/(enhance|improve)/i'
+      - '/^(enhance|improve)/i'
     body:
       - '/type: enhancement/i'
   - label: 'feature'
     title:
-      - '/feat/i'
+      - '/^feat/i'
     body:
       - '/type: feature/i'
   - label: 'dreprecated'
     title:
-      - '/deprecat(ed|ion)/i'
+      - '/^deprecat(ed|ion)/i'
     body:
       - '/type: deprecat(ed|ion)/i'
 template: |


### PR DESCRIPTION
Over the last week I seen at least 2-3 cases where labeler added more than one of `feature`, `bug`, `skip-changelog` to the same pull-request. This change should prevent this from happening again.

Related: https://github.com/release-drafter/release-drafter/issues/1022