### PR TITLE
Revert #36

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,10 +11,6 @@ on:
       - 'releases/**'
       - 'stable/**'
   workflow_call:  # allows reuse of this workflow from other devtools repos
-    secrets:
-      GITHUB_TOKEN:
-        description: 'Github token needed for access to release drafts'
-        required: true
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Github does not allow use of the reserved name, giving error parsing called workflow "ansible-community/devtools/.github/workflows/push.yml@main": secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it would collide with system reserved name